### PR TITLE
Added a 2 week sprint plan md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Detailed system documentation and architecture diagrams are available in the fol
 - [Test Case Development](TEST-CASES.md)
 - [Agile User Stories](USER-STORIES.md)
 - [Product Backlog](PRODUCT-BACKLOG.md)
+- [Sprint Planning](SPRINT-PLAN.md)
 
 ## Technology Stack (Planned)
 

--- a/SPRINT-PLAN.md
+++ b/SPRINT-PLAN.md
@@ -1,0 +1,44 @@
+# Sprint Planning
+
+## 1. Sprint Goal
+
+This 2-week sprint aims to deliver a usable MVP flow that allows a customer to create an account, securely sign in, browse available car wash services, book a service slot, and join the virtual queue. Completing this flow provides the project’s first end-to-end customer journey and establishes the technical foundation for future operational and reporting features.
+
+By the end of the sprint, the team should have reliable core APIs, validated data handling, and basic user-facing endpoints/pages that support booking and queue entry with proper authentication. This creates immediate business value by enabling digital self-service, reducing manual booking overhead, and preparing the platform for staff-side management features in later sprints.
+
+---
+
+## 2. Selected User Stories
+
+- US-001 – Register account
+- US-002 – Authenticate user
+- US-003 – Browse service catalog
+- US-004 – Create booking
+- US-005 – Join virtual queue
+
+---
+
+## 3. Sprint Backlog (Tasks)
+
+| Task ID | Task Description | Assigned To | Estimated Hours | Status |
+|--------|-----------------|-------------|-----------------|--------|
+| T-001 | Design and implement user database schema (users, roles, auth fields) for US-001/US-002 | Backend Dev | 5 | To Do |
+| T-002 | Build register account API endpoint with input validation and unique email checks (US-001) | Backend Dev | 6 | To Do |
+| T-003 | Implement password hashing and secure credential persistence for registration/authentication (US-001, US-002) | Backend Dev | 4 | To Do |
+| T-004 | Build login/authentication API with token/session generation and invalid-credential handling (US-002) | Backend Dev | 6 | To Do |
+| T-005 | Create service catalog schema/seed data and active-service query endpoint (US-003) | Backend Dev | 5 | To Do |
+| T-006 | Build booking schema and create-booking API with slot availability/past-time validation (US-004) | Backend Dev | 8 | To Do |
+| T-007 | Implement virtual queue schema and join-queue API with queue number and ETA calculation (US-005) | Backend Dev | 8 | To Do |
+| T-008 | Develop basic registration and login UI forms integrated with auth APIs (US-001, US-002) | Frontend Dev | 7 | To Do |
+| T-009 | Develop service catalog UI view to display service name, description, and pricing (US-003) | Frontend Dev | 5 | To Do |
+| T-010 | Develop booking creation UI flow (service + date/time selection + confirmation) (US-004) | Frontend Dev | 7 | To Do |
+| T-011 | Develop join virtual queue UI action and confirmation display (queue number + ETA) (US-005) | Frontend Dev | 6 | To Do |
+| T-012 | Add integration tests for auth, catalog retrieval, booking creation, and queue join happy paths (US-001 to US-005) | Dev Team | 7 | To Do |
+
+---
+
+## 4. Notes
+
+- All sprint tasks are derived directly from selected Must-have user stories (US-001 to US-005).
+- Hour estimates are sized for a 2-week sprint and include implementation plus basic verification.
+- This sprint focuses on the core system foundation and a usable customer-facing vertical slice for MVP delivery.


### PR DESCRIPTION
Created SPRINT_PLAN.md with a clear 2-week MVP-aligned sprint goal focused on core customer flow (register → authenticate → browse catalog → create booking → join queue).

Selected 5 Must-have user stories (US-001 to US-005) as the sprint scope, matching the requested vertical slice for MVP delivery.

Added a sprint backlog table with 12 executable tasks (T-001 to T-012), each with assignee, hour estimate, and initial To Do status.

Added sprint notes confirming task derivation from stories, 2-week estimation intent, and focus on core foundation work