### PR TITLE
Implement all six creational design patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,18 @@ The system will be developed using the following technologies:
 - C4 Model using Mermaid diagrams
 
 ## Project Status
+
+## Assignment 10: Creational Pattern Implementation
+
+For Assignment 10, all six creational design patterns were implemented as required and adapted to the car wash booking and queue management domain.
+
+| Pattern | Implementation | Purpose |
+|--------|----------------|---------|
+| Simple Factory | `VehicleFactory` and vehicle variants | Centralized vehicle creation for booking/registration workflows |
+| Factory Method | Notification sender factories and senders | Create channel-specific notification senders (email/SMS) without hard-coding |
+| Abstract Factory | Customer/Admin dashboard component families | Generate related role-based UI components consistently |
+| Builder | `BookingBuilder` (with `BuiltBooking`) | Construct booking data step-by-step with required-field validation |
+| Prototype | Service prototype templates and registry | Clone reusable wash service templates like `BASIC_WASH` and `PREMIUM_WASH` |
+| Singleton | `ApplicationConfig` | Provide a single, shared application-level configuration instance |
+
+Although not every creational pattern would be required in a small MVP, all six were implemented for academic demonstration and to show different object creation strategies.

--- a/README.md
+++ b/README.md
@@ -81,18 +81,3 @@ The system will be developed using the following technologies:
 - C4 Model using Mermaid diagrams
 
 ## Project Status
-
-## Assignment 10: Creational Pattern Implementation
-
-For Assignment 10, all six creational design patterns were implemented as required and adapted to the car wash booking and queue management domain.
-
-| Pattern | Implementation | Purpose |
-|--------|----------------|---------|
-| Simple Factory | `VehicleFactory` and vehicle variants | Centralized vehicle creation for booking/registration workflows |
-| Factory Method | Notification sender factories and senders | Create channel-specific notification senders (email/SMS) without hard-coding |
-| Abstract Factory | Customer/Admin dashboard component families | Generate related role-based UI components consistently |
-| Builder | `BookingBuilder` (with `BuiltBooking`) | Construct booking data step-by-step with required-field validation |
-| Prototype | Service prototype templates and registry | Clone reusable wash service templates like `BASIC_WASH` and `PREMIUM_WASH` |
-| Singleton | `ApplicationConfig` | Provide a single, shared application-level configuration instance |
-
-Although not every creational pattern would be required in a small MVP, all six were implemented for academic demonstration and to show different object creation strategies.

--- a/src/main/java/com/carwash/creational_patterns/abstract_factory/ActionButton.java
+++ b/src/main/java/com/carwash/creational_patterns/abstract_factory/ActionButton.java
@@ -1,0 +1,5 @@
+package com.carwash.creational_patterns.abstract_factory;
+
+public interface ActionButton {
+    String render();
+}

--- a/src/main/java/com/carwash/creational_patterns/abstract_factory/AdminActionButton.java
+++ b/src/main/java/com/carwash/creational_patterns/abstract_factory/AdminActionButton.java
@@ -1,0 +1,8 @@
+package com.carwash.creational_patterns.abstract_factory;
+
+public class AdminActionButton implements ActionButton {
+    @Override
+    public String render() {
+        return "Admin Button: Advance Queue";
+    }
+}

--- a/src/main/java/com/carwash/creational_patterns/abstract_factory/AdminDashboardFactory.java
+++ b/src/main/java/com/carwash/creational_patterns/abstract_factory/AdminDashboardFactory.java
@@ -1,0 +1,18 @@
+package com.carwash.creational_patterns.abstract_factory;
+
+public class AdminDashboardFactory implements DashboardComponentFactory {
+    @Override
+    public NavigationMenu createNavigationMenu() {
+        return new AdminNavigationMenu();
+    }
+
+    @Override
+    public DashboardPanel createDashboardPanel() {
+        return new AdminDashboardPanel();
+    }
+
+    @Override
+    public ActionButton createActionButton() {
+        return new AdminActionButton();
+    }
+}

--- a/src/main/java/com/carwash/creational_patterns/abstract_factory/AdminDashboardPanel.java
+++ b/src/main/java/com/carwash/creational_patterns/abstract_factory/AdminDashboardPanel.java
@@ -1,0 +1,8 @@
+package com.carwash.creational_patterns.abstract_factory;
+
+public class AdminDashboardPanel implements DashboardPanel {
+    @Override
+    public String render() {
+        return "Admin Panel: Live Queue and Service Throughput";
+    }
+}

--- a/src/main/java/com/carwash/creational_patterns/abstract_factory/AdminNavigationMenu.java
+++ b/src/main/java/com/carwash/creational_patterns/abstract_factory/AdminNavigationMenu.java
@@ -1,0 +1,8 @@
+package com.carwash.creational_patterns.abstract_factory;
+
+public class AdminNavigationMenu implements NavigationMenu {
+    @Override
+    public String render() {
+        return "Admin Menu: Dashboard | Queue | Services | Reports";
+    }
+}

--- a/src/main/java/com/carwash/creational_patterns/abstract_factory/CustomerActionButton.java
+++ b/src/main/java/com/carwash/creational_patterns/abstract_factory/CustomerActionButton.java
@@ -1,0 +1,8 @@
+package com.carwash.creational_patterns.abstract_factory;
+
+public class CustomerActionButton implements ActionButton {
+    @Override
+    public String render() {
+        return "Customer Button: Book Wash";
+    }
+}

--- a/src/main/java/com/carwash/creational_patterns/abstract_factory/CustomerDashboardFactory.java
+++ b/src/main/java/com/carwash/creational_patterns/abstract_factory/CustomerDashboardFactory.java
@@ -1,0 +1,18 @@
+package com.carwash.creational_patterns.abstract_factory;
+
+public class CustomerDashboardFactory implements DashboardComponentFactory {
+    @Override
+    public NavigationMenu createNavigationMenu() {
+        return new CustomerNavigationMenu();
+    }
+
+    @Override
+    public DashboardPanel createDashboardPanel() {
+        return new CustomerDashboardPanel();
+    }
+
+    @Override
+    public ActionButton createActionButton() {
+        return new CustomerActionButton();
+    }
+}

--- a/src/main/java/com/carwash/creational_patterns/abstract_factory/CustomerDashboardPanel.java
+++ b/src/main/java/com/carwash/creational_patterns/abstract_factory/CustomerDashboardPanel.java
@@ -1,0 +1,8 @@
+package com.carwash.creational_patterns.abstract_factory;
+
+public class CustomerDashboardPanel implements DashboardPanel {
+    @Override
+    public String render() {
+        return "Customer Panel: Upcoming Booking and Queue Position";
+    }
+}

--- a/src/main/java/com/carwash/creational_patterns/abstract_factory/CustomerNavigationMenu.java
+++ b/src/main/java/com/carwash/creational_patterns/abstract_factory/CustomerNavigationMenu.java
@@ -1,0 +1,8 @@
+package com.carwash.creational_patterns.abstract_factory;
+
+public class CustomerNavigationMenu implements NavigationMenu {
+    @Override
+    public String render() {
+        return "Customer Menu: Home | My Bookings | Notifications";
+    }
+}

--- a/src/main/java/com/carwash/creational_patterns/abstract_factory/DashboardComponentFactory.java
+++ b/src/main/java/com/carwash/creational_patterns/abstract_factory/DashboardComponentFactory.java
@@ -1,0 +1,7 @@
+package com.carwash.creational_patterns.abstract_factory;
+
+public interface DashboardComponentFactory {
+    NavigationMenu createNavigationMenu();
+    DashboardPanel createDashboardPanel();
+    ActionButton createActionButton();
+}

--- a/src/main/java/com/carwash/creational_patterns/abstract_factory/DashboardPanel.java
+++ b/src/main/java/com/carwash/creational_patterns/abstract_factory/DashboardPanel.java
@@ -1,0 +1,5 @@
+package com.carwash.creational_patterns.abstract_factory;
+
+public interface DashboardPanel {
+    String render();
+}

--- a/src/main/java/com/carwash/creational_patterns/abstract_factory/NavigationMenu.java
+++ b/src/main/java/com/carwash/creational_patterns/abstract_factory/NavigationMenu.java
@@ -1,0 +1,5 @@
+package com.carwash.creational_patterns.abstract_factory;
+
+public interface NavigationMenu {
+    String render();
+}

--- a/src/main/java/com/carwash/creational_patterns/builder/BookingBuilder.java
+++ b/src/main/java/com/carwash/creational_patterns/builder/BookingBuilder.java
@@ -1,0 +1,57 @@
+package com.carwash.creational_patterns.builder;
+
+import java.time.LocalDateTime;
+
+public class BookingBuilder {
+    private String customerName;
+    private String serviceName;
+    private String vehiclePlateNumber;
+    private LocalDateTime scheduledDateTime;
+    private String specialRequest;
+
+    public BookingBuilder customerName(String customerName) {
+        this.customerName = customerName;
+        return this;
+    }
+
+    public BookingBuilder serviceName(String serviceName) {
+        this.serviceName = serviceName;
+        return this;
+    }
+
+    public BookingBuilder vehiclePlateNumber(String vehiclePlateNumber) {
+        this.vehiclePlateNumber = vehiclePlateNumber;
+        return this;
+    }
+
+    public BookingBuilder scheduledDateTime(LocalDateTime scheduledDateTime) {
+        this.scheduledDateTime = scheduledDateTime;
+        return this;
+    }
+
+    public BookingBuilder specialRequest(String specialRequest) {
+        this.specialRequest = specialRequest;
+        return this;
+    }
+
+    public BuiltBooking build() {
+        if (isBlank(customerName)) {
+            throw new IllegalStateException("Customer name is required");
+        }
+        if (isBlank(serviceName)) {
+            throw new IllegalStateException("Service name is required");
+        }
+        if (isBlank(vehiclePlateNumber)) {
+            throw new IllegalStateException("Vehicle plate number is required");
+        }
+        if (scheduledDateTime == null) {
+            throw new IllegalStateException("Scheduled date/time is required");
+        }
+
+        return new BuiltBooking(customerName, serviceName, vehiclePlateNumber, scheduledDateTime, specialRequest);
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/src/main/java/com/carwash/creational_patterns/builder/BuiltBooking.java
+++ b/src/main/java/com/carwash/creational_patterns/builder/BuiltBooking.java
@@ -1,0 +1,25 @@
+package com.carwash.creational_patterns.builder;
+
+import java.time.LocalDateTime;
+
+public class BuiltBooking {
+    private final String customerName;
+    private final String serviceName;
+    private final String vehiclePlateNumber;
+    private final LocalDateTime scheduledDateTime;
+    private final String specialRequest;
+
+    public BuiltBooking(String customerName, String serviceName, String vehiclePlateNumber, LocalDateTime scheduledDateTime, String specialRequest) {
+        this.customerName = customerName;
+        this.serviceName = serviceName;
+        this.vehiclePlateNumber = vehiclePlateNumber;
+        this.scheduledDateTime = scheduledDateTime;
+        this.specialRequest = specialRequest;
+    }
+
+    public String getCustomerName() { return customerName; }
+    public String getServiceName() { return serviceName; }
+    public String getVehiclePlateNumber() { return vehiclePlateNumber; }
+    public LocalDateTime getScheduledDateTime() { return scheduledDateTime; }
+    public String getSpecialRequest() { return specialRequest; }
+}

--- a/src/main/java/com/carwash/creational_patterns/factory_method/EmailNotificationSender.java
+++ b/src/main/java/com/carwash/creational_patterns/factory_method/EmailNotificationSender.java
@@ -1,0 +1,8 @@
+package com.carwash.creational_patterns.factory_method;
+
+public class EmailNotificationSender implements NotificationSender {
+    @Override
+    public String send(String recipient, String message) {
+        return "Email sent to " + recipient + ": " + message;
+    }
+}

--- a/src/main/java/com/carwash/creational_patterns/factory_method/EmailNotificationSenderFactory.java
+++ b/src/main/java/com/carwash/creational_patterns/factory_method/EmailNotificationSenderFactory.java
@@ -1,0 +1,8 @@
+package com.carwash.creational_patterns.factory_method;
+
+public class EmailNotificationSenderFactory extends NotificationSenderFactory {
+    @Override
+    public NotificationSender createSender() {
+        return new EmailNotificationSender();
+    }
+}

--- a/src/main/java/com/carwash/creational_patterns/factory_method/NotificationSender.java
+++ b/src/main/java/com/carwash/creational_patterns/factory_method/NotificationSender.java
@@ -1,0 +1,5 @@
+package com.carwash.creational_patterns.factory_method;
+
+public interface NotificationSender {
+    String send(String recipient, String message);
+}

--- a/src/main/java/com/carwash/creational_patterns/factory_method/NotificationSenderFactory.java
+++ b/src/main/java/com/carwash/creational_patterns/factory_method/NotificationSenderFactory.java
@@ -1,0 +1,5 @@
+package com.carwash.creational_patterns.factory_method;
+
+public abstract class NotificationSenderFactory {
+    public abstract NotificationSender createSender();
+}

--- a/src/main/java/com/carwash/creational_patterns/factory_method/SmsNotificationSender.java
+++ b/src/main/java/com/carwash/creational_patterns/factory_method/SmsNotificationSender.java
@@ -1,0 +1,8 @@
+package com.carwash.creational_patterns.factory_method;
+
+public class SmsNotificationSender implements NotificationSender {
+    @Override
+    public String send(String recipient, String message) {
+        return "SMS sent to " + recipient + ": " + message;
+    }
+}

--- a/src/main/java/com/carwash/creational_patterns/factory_method/SmsNotificationSenderFactory.java
+++ b/src/main/java/com/carwash/creational_patterns/factory_method/SmsNotificationSenderFactory.java
@@ -1,0 +1,8 @@
+package com.carwash.creational_patterns.factory_method;
+
+public class SmsNotificationSenderFactory extends NotificationSenderFactory {
+    @Override
+    public NotificationSender createSender() {
+        return new SmsNotificationSender();
+    }
+}

--- a/src/main/java/com/carwash/creational_patterns/prototype/ServicePrototype.java
+++ b/src/main/java/com/carwash/creational_patterns/prototype/ServicePrototype.java
@@ -1,0 +1,5 @@
+package com.carwash.creational_patterns.prototype;
+
+public interface ServicePrototype extends Cloneable {
+    ServicePrototype cloneService();
+}

--- a/src/main/java/com/carwash/creational_patterns/prototype/ServicePrototypeRegistry.java
+++ b/src/main/java/com/carwash/creational_patterns/prototype/ServicePrototypeRegistry.java
@@ -1,0 +1,29 @@
+package com.carwash.creational_patterns.prototype;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ServicePrototypeRegistry {
+    private final Map<String, ServicePrototype> templates = new HashMap<>();
+
+    public ServicePrototypeRegistry() {
+        templates.put("BASIC_WASH", new WashServicePrototype("BASIC_WASH", "Basic Wash", BigDecimal.valueOf(80), 25));
+        templates.put("PREMIUM_WASH", new WashServicePrototype("PREMIUM_WASH", "Premium Wash", BigDecimal.valueOf(150), 45));
+    }
+
+    public void addTemplate(String templateKey, ServicePrototype prototype) {
+        if (templateKey == null || templateKey.isBlank() || prototype == null) {
+            throw new IllegalArgumentException("Template key and prototype must be provided");
+        }
+        templates.put(templateKey, prototype);
+    }
+
+    public ServicePrototype getClonedTemplate(String templateKey) {
+        ServicePrototype prototype = templates.get(templateKey);
+        if (prototype == null) {
+            throw new IllegalArgumentException("No prototype found for key: " + templateKey);
+        }
+        return prototype.cloneService();
+    }
+}

--- a/src/main/java/com/carwash/creational_patterns/prototype/WashServicePrototype.java
+++ b/src/main/java/com/carwash/creational_patterns/prototype/WashServicePrototype.java
@@ -1,0 +1,31 @@
+package com.carwash.creational_patterns.prototype;
+
+import java.math.BigDecimal;
+
+public class WashServicePrototype implements ServicePrototype {
+    private String serviceCode;
+    private String serviceName;
+    private BigDecimal price;
+    private int estimatedDurationMin;
+
+    public WashServicePrototype(String serviceCode, String serviceName, BigDecimal price, int estimatedDurationMin) {
+        this.serviceCode = serviceCode;
+        this.serviceName = serviceName;
+        this.price = price;
+        this.estimatedDurationMin = estimatedDurationMin;
+    }
+
+    @Override
+    public ServicePrototype cloneService() {
+        return new WashServicePrototype(serviceCode, serviceName, price, estimatedDurationMin);
+    }
+
+    public String getServiceCode() { return serviceCode; }
+    public String getServiceName() { return serviceName; }
+    public BigDecimal getPrice() { return price; }
+    public int getEstimatedDurationMin() { return estimatedDurationMin; }
+
+    public void setServiceName(String serviceName) { this.serviceName = serviceName; }
+    public void setPrice(BigDecimal price) { this.price = price; }
+    public void setEstimatedDurationMin(int estimatedDurationMin) { this.estimatedDurationMin = estimatedDurationMin; }
+}

--- a/src/main/java/com/carwash/creational_patterns/simple_factory/FactoryVehicle.java
+++ b/src/main/java/com/carwash/creational_patterns/simple_factory/FactoryVehicle.java
@@ -1,0 +1,6 @@
+package com.carwash.creational_patterns.simple_factory;
+
+public interface FactoryVehicle {
+    String getTypeName();
+    int getRecommendedQueueSlotMinutes();
+}

--- a/src/main/java/com/carwash/creational_patterns/simple_factory/SedanVehicle.java
+++ b/src/main/java/com/carwash/creational_patterns/simple_factory/SedanVehicle.java
@@ -1,0 +1,13 @@
+package com.carwash.creational_patterns.simple_factory;
+
+public class SedanVehicle implements FactoryVehicle {
+    @Override
+    public String getTypeName() {
+        return "Sedan";
+    }
+
+    @Override
+    public int getRecommendedQueueSlotMinutes() {
+        return 30;
+    }
+}

--- a/src/main/java/com/carwash/creational_patterns/simple_factory/SuvVehicle.java
+++ b/src/main/java/com/carwash/creational_patterns/simple_factory/SuvVehicle.java
@@ -1,0 +1,13 @@
+package com.carwash.creational_patterns.simple_factory;
+
+public class SuvVehicle implements FactoryVehicle {
+    @Override
+    public String getTypeName() {
+        return "SUV";
+    }
+
+    @Override
+    public int getRecommendedQueueSlotMinutes() {
+        return 40;
+    }
+}

--- a/src/main/java/com/carwash/creational_patterns/simple_factory/TruckVehicle.java
+++ b/src/main/java/com/carwash/creational_patterns/simple_factory/TruckVehicle.java
@@ -1,0 +1,13 @@
+package com.carwash.creational_patterns.simple_factory;
+
+public class TruckVehicle implements FactoryVehicle {
+    @Override
+    public String getTypeName() {
+        return "Truck";
+    }
+
+    @Override
+    public int getRecommendedQueueSlotMinutes() {
+        return 50;
+    }
+}

--- a/src/main/java/com/carwash/creational_patterns/simple_factory/VehicleFactory.java
+++ b/src/main/java/com/carwash/creational_patterns/simple_factory/VehicleFactory.java
@@ -1,0 +1,18 @@
+package com.carwash.creational_patterns.simple_factory;
+
+public final class VehicleFactory {
+    private VehicleFactory() {
+    }
+
+    public static FactoryVehicle createVehicle(VehicleType type) {
+        if (type == null) {
+            throw new IllegalArgumentException("Vehicle type must not be null");
+        }
+
+        return switch (type) {
+            case SEDAN -> new SedanVehicle();
+            case SUV -> new SuvVehicle();
+            case TRUCK -> new TruckVehicle();
+        };
+    }
+}

--- a/src/main/java/com/carwash/creational_patterns/simple_factory/VehicleType.java
+++ b/src/main/java/com/carwash/creational_patterns/simple_factory/VehicleType.java
@@ -1,0 +1,7 @@
+package com.carwash.creational_patterns.simple_factory;
+
+public enum VehicleType {
+    SEDAN,
+    SUV,
+    TRUCK
+}

--- a/src/main/java/com/carwash/creational_patterns/singleton/ApplicationConfig.java
+++ b/src/main/java/com/carwash/creational_patterns/singleton/ApplicationConfig.java
@@ -1,0 +1,32 @@
+package com.carwash.creational_patterns.singleton;
+
+public class ApplicationConfig {
+    private String applicationName = "Car Wash Booking and Queue Management";
+    private int defaultQueueCapacity = 25;
+    private boolean notificationEnabled = true;
+
+    private ApplicationConfig() {
+    }
+
+    private static class Holder {
+        private static final ApplicationConfig INSTANCE = new ApplicationConfig();
+    }
+
+    public static ApplicationConfig getInstance() {
+        return Holder.INSTANCE;
+    }
+
+    public String getApplicationName() { return applicationName; }
+    public void setApplicationName(String applicationName) { this.applicationName = applicationName; }
+
+    public int getDefaultQueueCapacity() { return defaultQueueCapacity; }
+    public void setDefaultQueueCapacity(int defaultQueueCapacity) {
+        if (defaultQueueCapacity <= 0) {
+            throw new IllegalArgumentException("Default queue capacity must be greater than zero");
+        }
+        this.defaultQueueCapacity = defaultQueueCapacity;
+    }
+
+    public boolean isNotificationEnabled() { return notificationEnabled; }
+    public void setNotificationEnabled(boolean notificationEnabled) { this.notificationEnabled = notificationEnabled; }
+}


### PR DESCRIPTION
### Motivation
- Provide academic implementations of the six creational design patterns required by Assignment 10 and adapt each pattern to the car wash booking / queue management domain. 
- Keep pattern implementations self-contained and non-invasive to existing domain classes (avoid changing `Booking`, `User`, `Vehicle`, `Service`, etc.).

### Description
- Added package structure `com.carwash.creational_patterns` with subpackages: `simple_factory`, `factory_method`, `abstract_factory`, `builder`, `prototype`, and `singleton`, and implemented domain-relevant examples for each pattern (e.g. vehicle creation, notification senders, role dashboard components). 
- Implemented Simple Factory: `VehicleFactory`, `VehicleType`, `FactoryVehicle`, `SedanVehicle`, `SuvVehicle`, `TruckVehicle` in `simple_factory` with null/invalid handling via `IllegalArgumentException`.
- Implemented Factory Method: `NotificationSender`, `NotificationSenderFactory`, `EmailNotificationSenderFactory`, `SmsNotificationSenderFactory`, `EmailNotificationSender`, `SmsNotificationSender` in `factory_method` exposing `send(String recipient, String message)`.
- Implemented Abstract Factory: `DashboardComponentFactory` plus customer/admin families (`NavigationMenu`, `DashboardPanel`, `ActionButton` and their concrete `Customer*` / `Admin*` implementations) in `abstract_factory` with `render()` methods returning simple strings.
- Implemented Builder: `BookingBuilder` and a self-contained `BuiltBooking` in `builder` to construct booking-like objects with validation of required fields and throwing `IllegalStateException` on missing values.
- Implemented Prototype: `ServicePrototype`, `WashServicePrototype`, and `ServicePrototypeRegistry` in `prototype`, seeded with `BASIC_WASH` and `PREMIUM_WASH` and returning cloned copies via `cloneService()`.
- Implemented Singleton: `ApplicationConfig` in `singleton` using the thread-safe static holder idiom with `applicationName`, `defaultQueueCapacity`, and `notificationEnabled` and appropriate getters/setters.
- Updated `README.md` with an "Assignment 10" section and a table mapping each pattern to its implementation and purpose.

### Testing
- Ran `./mvnw test -q` but the wrapper was not executable in this environment resulting in a permission error, so wrapper tests were not executed.
- Ran `mvn test -q` which failed due to external dependency resolution (unable to download Spring Boot parent POM from Maven Central; HTTP 403), so a full automated build/test verification could not be completed here.
- No new unit tests were added as part of this change; existing test suite was not successfully executed due to the environment-related Maven resolution issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3cf8c80908323928224abd2234aaf)