### PR TITLE
Improve validation error responses with field-level messages

### DIFF
--- a/src/main/java/com/carwash/api/ApiExceptionHandler.java
+++ b/src/main/java/com/carwash/api/ApiExceptionHandler.java
@@ -11,25 +11,71 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.ServletWebRequest;
 
 import java.time.LocalDateTime;
+import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class ApiExceptionHandler {
-    
+
     @ExceptionHandler(ResourceNotFoundException.class)
-    public ResponseEntity<ApiErrorResponse> handleNotFound(ResourceNotFoundException ex, ServletWebRequest request) {
+    public ResponseEntity<ApiErrorResponse> handleNotFound(
+            ResourceNotFoundException ex,
+            ServletWebRequest request
+    ) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(new ApiErrorResponse(404, ex.getMessage(), LocalDateTime.now().toString(), request.getRequest().getRequestURI()));
+                .body(new ApiErrorResponse(
+                        404,
+                        ex.getMessage(),
+                        LocalDateTime.now().toString(),
+                        request.getRequest().getRequestURI()
+                ));
     }
 
-    @ExceptionHandler({BusinessRuleViolationException.class, MethodArgumentNotValidException.class, IllegalArgumentException.class})
-    public ResponseEntity<ApiErrorResponse> handleBadRequest(Exception ex, ServletWebRequest request) {
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiErrorResponse> handleValidationErrors(
+            MethodArgumentNotValidException ex,
+            ServletWebRequest request
+    ) {
+        String message = ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .sorted()
+                .collect(Collectors.joining("; "));
+
         return ResponseEntity.badRequest()
-                .body(new ApiErrorResponse(400, ex.getMessage(), LocalDateTime.now().toString(), request.getRequest().getRequestURI()));
+                .body(new ApiErrorResponse(
+                        400,
+                        "Validation failed: " + message,
+                        LocalDateTime.now().toString(),
+                        request.getRequest().getRequestURI()
+                ));
+    }
+
+    @ExceptionHandler({BusinessRuleViolationException.class, IllegalArgumentException.class})
+    public ResponseEntity<ApiErrorResponse> handleBadRequest(
+            Exception ex,
+            ServletWebRequest request
+    ) {
+        return ResponseEntity.badRequest()
+                .body(new ApiErrorResponse(
+                        400,
+                        ex.getMessage(),
+                        LocalDateTime.now().toString(),
+                        request.getRequest().getRequestURI()
+                ));
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiErrorResponse> handleInternalServerError(Exception ex, ServletWebRequest request) {
+    public ResponseEntity<ApiErrorResponse> handleInternalServerError(
+            Exception ex,
+            ServletWebRequest request
+    ) {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(new ApiErrorResponse(500, ex.getMessage(), LocalDateTime.now().toString(), request.getRequest().getRequestURI()));
+                .body(new ApiErrorResponse(
+                        500,
+                        ex.getMessage(),
+                        LocalDateTime.now().toString(),
+                        request.getRequest().getRequestURI()
+                ));
     }
 }

--- a/src/main/java/com/carwash/api/BookingController.java
+++ b/src/main/java/com/carwash/api/BookingController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
 
 import java.util.List;
 
@@ -57,12 +58,12 @@ public class BookingController {
             @ApiResponse(responseCode = "404", description = "Not found", content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
             @ApiResponse(responseCode = "500", description = "Internal server error", content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
     })
-    public Booking create(@RequestBody CreateBookingRequest req) {
+    public Booking create(@Valid @RequestBody CreateBookingRequest req) {
         return service.createBooking(req.toBooking());
     }
 
     @PutMapping("/{id}")
-    public Booking update(@PathVariable String id, @RequestBody CreateBookingRequest req) {
+    public Booking update(@PathVariable String id, @Valid @RequestBody CreateBookingRequest req) {
         Booking b = req.toBooking(); b.setBookingId(id); return service.updateBooking(b);
     }
 

--- a/src/main/java/com/carwash/api/dto/CreateBookingRequest.java
+++ b/src/main/java/com/carwash/api/dto/CreateBookingRequest.java
@@ -4,15 +4,49 @@ import com.carwash.domain.Booking;
 import com.carwash.domain.Service;
 import com.carwash.domain.User;
 import com.carwash.domain.Vehicle;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDateTime;
 
-public record CreateBookingRequest(String bookingId, String userId, String vehicleId, String serviceId, LocalDateTime scheduledDateTime, String specialRequest) {
+public record CreateBookingRequest(
+        @NotBlank(message = "bookingId is required")
+        String bookingId,
+
+        @NotBlank(message = "userId is required")
+        String userId,
+
+        @NotBlank(message = "vehicleId is required")
+        String vehicleId,
+
+        @NotBlank(message = "serviceId is required")
+        String serviceId,
+
+        @NotNull(message = "scheduledDateTime is required")
+        @Future(message = "scheduledDateTime must be in the future")
+        LocalDateTime scheduledDateTime,
+
+        String specialRequest
+) {
 
     public Booking toBooking() {
-        User user = new User(); user.setUserId(userId);
-        Vehicle vehicle = new Vehicle(); vehicle.setVehicleId(vehicleId);
-        Service service = new Service(); service.setServiceId(serviceId);
-        return new Booking(bookingId, user, vehicle, service, scheduledDateTime, specialRequest);
+        User user = new User();
+        user.setUserId(userId);
+
+        Vehicle vehicle = new Vehicle();
+        vehicle.setVehicleId(vehicleId);
+
+        Service service = new Service();
+        service.setServiceId(serviceId);
+
+        return new Booking(
+                bookingId,
+                user,
+                vehicle,
+                service,
+                scheduledDateTime,
+                specialRequest
+        );
     }
 }

--- a/src/main/java/com/carwash/api/dto/CreateBookingRequest.java
+++ b/src/main/java/com/carwash/api/dto/CreateBookingRequest.java
@@ -11,7 +11,7 @@ import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 
 public record CreateBookingRequest(
-        @NotBlank(message = "bookingId is required")
+        @NotBlank(message = "bookingId is required")  
         String bookingId,
 
         @NotBlank(message = "userId is required")

--- a/src/test/java/com/carwash/api/ApiIntegrationTest.java
+++ b/src/test/java/com/carwash/api/ApiIntegrationTest.java
@@ -7,6 +7,7 @@ import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import tools.jackson.databind.ObjectMapper;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -60,4 +61,28 @@ public class ApiIntegrationTest {
     void openApiDocsEndpointAvailable() throws Exception {
         mockMvc.perform(get("/v3/api-docs")).andExpect(status().isOk());
     }
+
+    @Test
+void bookingValidationErrorIncludesFieldLevelMessage() throws Exception {
+    String invalidBooking = """
+            {
+              "bookingId": "",
+              "userId": "",
+              "vehicleId": "v-test",
+              "serviceId": "s-test",
+              "scheduledDateTime": null,
+              "specialRequest": "validation test"
+            }
+            """;
+
+    mockMvc.perform(post("/api/bookings")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(invalidBooking))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("bookingId")))
+            .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("userId")))
+            .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("scheduledDateTime")))
+            .andExpect(jsonPath("$.path").value("/api/bookings"));
+}
 }


### PR DESCRIPTION
## Summary  

Improved validation error handling so request-body validation failures return clearer field-level messages.

This PR adds a dedicated handler for `MethodArgumentNotValidException`, applies validation to booking creation/update requests, and adds an integration test to confirm the response body includes invalid field names and readable validation reasons.

## Related Issue

Closes #76

## Changes Made

- Added a dedicated `MethodArgumentNotValidException` handler in `ApiExceptionHandler`.
- Removed `MethodArgumentNotValidException` from the generic bad-request exception group.
- Updated validation responses to return a stable message format like:

```text
Validation failed: bookingId: bookingId is required; scheduledDateTime: scheduledDateTime is required; userId: userId is required

- Added validation annotations to CreateBookingRequest:
@NotBlank for required ID fields
@NotNull for scheduledDateTime
@Future to require future booking times
- Added @Valid to booking create and update request bodies in BookingController.
- Added an integration test to verify that an invalid booking request returns HTTP 400 and includes field-level validation details in the response body.